### PR TITLE
Typo fixed

### DIFF
--- a/schema/fields.json
+++ b/schema/fields.json
@@ -180,7 +180,7 @@
                             "$ref": "./fields/span/full.json#/definitions/value"
                         },
                         {
-                            "$ref": "./fields/span/auto.json#/definitions/value"
+                            "$ref": "./fields/span/storm.json#/definitions/value"
                         }
                     ]
                 },


### PR DESCRIPTION
Now this is a duplication of the property `span: auto`
https://github.com/wintercms/vscode-extension/blob/ba53ff37b487db0a0ac0a0cfd670c32b6fa8b41f/schema/fields.json#L171

https://github.com/wintercms/vscode-extension/blob/ba53ff37b487db0a0ac0a0cfd670c32b6fa8b41f/schema/fields.json#L183

Must be a `span: storm`