### PR TITLE
Filters have been added to Twig syntax

### DIFF
--- a/syntax/twig.wintercms.tmLanguage.json
+++ b/syntax/twig.wintercms.tmLanguage.json
@@ -1087,7 +1087,7 @@
       "contentName": "meta.function.arguments.twig"
     },
     "twig-filters-warg": {
-      "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(batch|convert_encoding|date|date_modify|default|e(?:scape)?|finish|format|join|merge|number_format|replace|resize|round|slice|split|trans|transchoice|trim)(\\()",
+      "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(batch|convert_encoding|date|date_modify|default|e(?:scape)?|finish|format|join|merge|number_format|replace|resize|round|slice|slug|split|trans|transchoice|trim)(\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.twig"

--- a/syntax/twig.wintercms.tmLanguage.json
+++ b/syntax/twig.wintercms.tmLanguage.json
@@ -1087,7 +1087,7 @@
       "contentName": "meta.function.arguments.twig"
     },
     "twig-filters-warg": {
-      "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(batch|convert_encoding|date|date_modify|default|e(?:scape)?|format|join|merge|number_format|replace|resize|round|slice|split|trim)(\\()",
+      "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(batch|convert_encoding|date|date_modify|default|e(?:scape)?|finish|format|join|merge|number_format|replace|resize|round|slice|split|trans|transchoice|trim)(\\()",
       "beginCaptures": {
         "1": {
           "name": "support.function.twig"
@@ -1151,7 +1151,7 @@
           "name": "support.function.twig"
         }
       },
-      "match": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(abs|app|asset|capitalize|e(?:scape)?|first|imageWidth|imageHeight|join|(?:json|url)_encode|keys|last|length|lower|media|nl2br|number_format|page|raw|reverse|round|sort|striptags|theme|title|trim|upper)(?=[\\s\\|\\]\\}\\):,]|\\.\\.|\\*\\*)"
+      "match": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(abs|app|asset|camel|capitalize|e(?:scape)?|first|imageWidth|imageHeight|join|(?:json|url)_encode|keys|last|length|lower|md|md_(?:line|safe)|media|nl2br|number_format|page|plural|raw|reverse|round|singular|slug|snake|sort|striptags|studly|theme|title|trans|trim|upper)(?=[\\s\\|\\]\\}\\):,]|\\.\\.|\\*\\*)"
     },
     "twig-filters-warg-ud": {
       "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*)(\\()",


### PR DESCRIPTION
Added Twig filters:

- `camel`
- `finish` (params)
- `plural`
- `singular`
- `slug` (or params)
- `snake`
- `studly`
- `trans` (or params)
- `transchoice` (params)
- `md`
- `md_safe`
- `md_line`

https://github.com/wintercms/winter/blob/bb79834af1690c63cc642af72a560e5f7e0d3c4a/modules/system/ServiceProvider.php#L212-L223

## Screenshots

Before:

![twig-filters-before](https://github.com/wintercms/vscode-extension/assets/61043464/1cf6c19a-703c-40e4-beea-b1dffe2316fa)

After:

![twig-filters-after](https://github.com/wintercms/vscode-extension/assets/61043464/3231f901-b50b-43c6-be8b-871f90bf92ba)

## Examples

### Str

```twig
{{ 'test test'|camel }}

{{ 'test'|finish('/') }}

{{ 'test'|plural }}

{{ 'letters'|singular }}

{{ 'test test'|slug }}

{{ 'test test'|slug('+') }}

{{ 'test test'|snake }}

{{ 'test test'|studly }}
```

### trans

```twig
{{ 'I love Winter CMS.'|trans }}

{{ ':name loves Winter CMS.'|trans({ name: 'Samuel' }) }}

{{ 'snowflake|snowflakes'|transchoice(8) }}
```

### Markdown

```twig
{{ '**Text** is bold.'|md }}

{{ '**Text** is bold.'|md_line }}

{{ '    **Text** is bold.'|md_safe }}
```