### PR TITLE
Filters have been added to Twig syntax

### DIFF
--- a/syntax/twig.wintercms.tmLanguage.json
+++ b/syntax/twig.wintercms.tmLanguage.json
@@ -1151,7 +1151,7 @@
           "name": "support.function.twig"
         }
       },
-      "match": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(abs|app|asset|camel|capitalize|e(?:scape)?|first|imageWidth|imageHeight|join|(?:json|url)_encode|keys|last|length|lower|md|md_(?:line|safe)|media|nl2br|number_format|page|plural|raw|reverse|round|singular|slug|snake|sort|striptags|studly|theme|title|trans|trim|upper)(?=[\\s\\|\\]\\}\\):,]|\\.\\.|\\*\\*)"
+      "match": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)(abs|app|asset|camel|capitalize|e(?:scape)?|first|imageWidth|imageHeight|join|(?:json|url)_encode|keys|last|length|lower|md|md_(?:line|safe)|media|nl2br|number_format|page|plural|raw|reverse|round|singular|slug|snake|sort|striptags|studly|theme|time_(?:since|tense)|title|trans|trim|upper)(?=[\\s\\|\\]\\}\\):,]|\\.\\.|\\*\\*)"
     },
     "twig-filters-warg-ud": {
       "begin": "(?<=(?:[a-zA-Z0-9_\\x{7f}-\\x{ff}\\]\\)\\'\\\"]\\|)|\\{%\\sfilter\\s)([a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*)(\\()",


### PR DESCRIPTION
Added Twig filters `time_since` and `time_tense`.

https://github.com/wintercms/winter/blob/d2f284ce6476a3b3d81215281488724a735cb35e/modules/system/ServiceProvider.php#L224-L225

Examples of using:
```twig
{{ item.created_at|time_tense }}

{{ '2021-03-06 14:25:55'|time_since }}

{{ 'February 14, 2024 14:30'|time_since }}

{{ '2021-03-06 14:25:55'|time_tense }}
```